### PR TITLE
fix: bug in packaging extension

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -72,8 +72,8 @@ jobs:
         ls -la
         zip -r ../gmail-inbox-labels.zip .
         echo "Zip creation completed"
-        cd ..
-        echo "Back to original directory: $(pwd)"
+        cd "$GITHUB_WORKSPACE"
+        echo "Back to workspace directory: $(pwd)"
 
         # Clean up temporary files
         rm -rf "$TEMP_DIR"

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -87,7 +87,7 @@ jobs:
         retention-days: 30
 
     - name: Create Release
-      # if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
         files: |
@@ -97,3 +97,19 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Debug Release (Manual Trigger)
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "Debug mode: Manual workflow dispatch"
+        echo "Current ref: ${{ github.ref }}"
+        echo "Current branch: ${{ github.ref_name }}"
+        echo "Files in current directory:"
+        ls -la
+        echo ""
+        echo "Checking for extension files:"
+        ls -la gmail-inbox-labels.* || echo "No extension files found"
+        echo ""
+        echo "To create a release, push a tag:"
+        echo "git tag v1.2.2"
+        echo "git push origin v1.2.2"

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -70,7 +70,7 @@ jobs:
         echo "Current directory: $(pwd)"
         echo "Files to zip:"
         ls -la
-        zip -r ../gmail-inbox-labels.zip .
+        zip -r "$GITHUB_WORKSPACE/gmail-inbox-labels.zip" .
         echo "Zip creation completed"
         cd "$GITHUB_WORKSPACE"
         echo "Back to workspace directory: $(pwd)"
@@ -125,5 +125,5 @@ jobs:
         ls -la gmail-inbox-labels.* || echo "No extension files found"
         echo ""
         echo "To create a release, push a tag:"
-        echo "git tag v1.2.2"
-        echo "git push origin v1.2.2"
+        echo "git tag v1.2.3"
+        echo "git push origin v1.2.3"

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -87,7 +87,7 @@ jobs:
         retention-days: 30
 
     - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/')
+      # if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
         files: |

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -65,9 +65,15 @@ jobs:
         crx pack "$TEMP_DIR" -o gmail-inbox-labels.crx -p pem_key.pem
 
         # Create a zip file for Chrome Web Store
+        echo "Creating zip file..."
         cd "$TEMP_DIR"
+        echo "Current directory: $(pwd)"
+        echo "Files to zip:"
+        ls -la
         zip -r ../gmail-inbox-labels.zip .
+        echo "Zip creation completed"
         cd ..
+        echo "Back to original directory: $(pwd)"
 
         # Clean up temporary files
         rm -rf "$TEMP_DIR"
@@ -76,6 +82,14 @@ jobs:
         # Verify files were created
         echo "Checking for created files:"
         ls -la gmail-inbox-labels.*
+
+        # Check if zip file was created successfully
+        if [ ! -f "gmail-inbox-labels.zip" ]; then
+          echo "❌ Error: gmail-inbox-labels.zip was not created!"
+          echo "Contents of temp directory before cleanup:"
+          ls -la "$TEMP_DIR"
+          exit 1
+        fi
 
     - name: Upload extension package
       uses: actions/upload-artifact@v4

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -64,11 +67,15 @@ jobs:
         # Create a zip file for Chrome Web Store
         cd "$TEMP_DIR"
         zip -r ../gmail-inbox-labels.zip .
-        cd - > /dev/null
+        cd ..
 
         # Clean up temporary files
         rm -rf "$TEMP_DIR"
         rm -f pem_key.pem
+
+        # Verify files were created
+        echo "Checking for created files:"
+        ls -la gmail-inbox-labels.*
 
     - name: Upload extension package
       uses: actions/upload-artifact@v4

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gmail Inbox Labels",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Modifies Gmail label buttons to show only emails in the inbox.",
   "permissions": [
     "storage"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-inbox-labels",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Chrome extension that modifies Gmail label buttons to show only emails in the inbox",
   "main": "content.js",
   "scripts": {


### PR DESCRIPTION
- fix bug in package script
- bump version to v1.2.2

## Summary by Sourcery

Update the GitHub Actions packaging workflow to grant necessary permissions, correct directory navigation, and verify generated extension files.

Bug Fixes:
- Fix directory navigation in the packaging job by replacing an unreliable 'cd - > /dev/null' with a direct 'cd ..'.

CI:
- Add 'contents: write' permission for the workflow to allow artifact handling.
- Introduce a debug step to list and verify the created extension files before upload.

## Summary by Sourcery

Update extension packaging workflow with improved logging, error handling, and manual debug trigger, and bump extension version to 1.2.2.

Bug Fixes:
- Verify zip file creation and abort packaging on failure to fix packaging extension bug.

Enhancements:
- Add debug logging and directory checks to the packaging workflow steps.

CI:
- Grant 'contents: write' permission for workflow to enable artifact upload.
- Add a manual 'Debug Release' job for workflow dispatch.

Chores:
- Bump extension version from 1.2.1 to 1.2.2 in manifest.json and package.json.